### PR TITLE
fix: update menu pricing to reflect current rates

### DIFF
--- a/data/homepage.yml
+++ b/data/homepage.yml
@@ -90,7 +90,7 @@ pricing:
 
         - title: "とんかつ（ロース）"
           description: "味のあるロース肉です"
-          price: "370円"
+          price: "380円"
 
         - title: "上とんかつ（ロース）"
           description: "リブロースを使用"
@@ -130,137 +130,137 @@ pricing:
 
         - title: "焼シャケ"
           description: ""
-          price: "140円"
+          price: "150円"
 
     - sectionName: "お弁当"
       pricingItem:
         - title: "コロッケ弁当"
           description: "シャケ入り"
-          price: "570円"
+          price: "610円"
 
         - title: "メンチ弁当"
           description: "シャケ入り"
-          price: "590円"
+          price: "630円"
 
         - title: "コロッケ・ハムカツ弁当"
           description: ""
-          price: "540円"
+          price: "570円"
 
         - title: "コロッケ・アジフライ弁当"
           description: ""
-          price: "540円"
+          price: "570円"
 
         - title: "コロッケ・唐揚げ弁当"
           description: ""
-          price: "570円"
+          price: "600円"
 
         - title: "メンチ・コロッケ弁当"
           description: ""
-          price: "570円"
+          price: "600円"
 
         - title: "メンチ・ハムカツ弁当"
           description: ""
-          price: "570円"
+          price: "600円"
 
         - title: "メンチ・アジフライ弁当"
           description: ""
-          price: "570円"
+          price: "600円"
 
         - title: "メンチ・唐揚げ弁当"
           description: ""
-          price: "590円"
+          price: "620円"
 
         - title: "からあげ弁当"
           description: "シャケ入り"
-          price: "590円"
+          price: "630円"
 
         - title: "ハム・唐揚げ弁当"
           description: ""
-          price: "570円"
+          price: "600円"
 
         - title: "スペシャル弁当"
           description: "コロッケ・海老フライ・ひれ一口カツ"
-          price: "720円"
+          price: "750円"
 
         - title: "海鮮ミックス弁当"
           description: "アジフライ・海老フライ・イカフライ"
-          price: "630円"
+          price: "660円"
 
         - title: "アジフライ弁当"
           description: "シャケ入り"
-          price: "600円"
+          price: "640円"
 
         - title: "アジ・唐揚げ弁当"
           description: ""
-          price: "600円"
+          price: "630円"
 
         - title: "イカフライ弁当"
           description: "シャケ入り"
-          price: "600円"
+          price: "640円"
 
         - title: "イカ・ハム弁当"
           description: ""
-          price: "600円"
+          price: "630円"
 
         - title: "イカ・唐揚げ弁当"
           description: ""
-          price: "600円"
+          price: "630円"
 
         - title: "鮭フライ弁当"
           description: ""
-          price: "540円"
+          price: "570円"
 
         - title: "海老フライ弁当"
           description: "シャケ入り"
-          price: "760円"
+          price: "800円"
 
         - title: "ヒレかつ弁当"
           description: "シャケ入り"
-          price: "720円"
+          price: "760円"
 
         - title: "とんかつ弁当"
           description: ""
-          price: "720円"
+          price: "750円"
 
         - title: "かつ丼"
           description: ""
-          price: "630円"
+          price: "650円"
 
         - title: "ヒレかつ丼"
           description: ""
-          price: "730円"
+          price: "750円"
 
         - title: "餃子弁当"
           description: ""
-          price: "590円"
+          price: "620円"
 
         - title: "焼肉弁当"
           description: "豚ロースを使用"
-          price: "630円"
+          price: "660円"
 
         - title: "ハンバーグ弁当"
           description: ""
-          price: "630円"
+          price: "660円"
 
         - title: "ハンバーグ・エビフライ弁当"
           description: ""
-          price: "770円"
+          price: "800円"
 
         - title: "幕の内弁当"
           description: "アジフライ・ひれ一口カツ・焼肉・シャケ入り"
-          price: "840円"
+          price: "880円"
 
         - title: "特製幕の内弁当"
           description: "海老フライ・アジフライ・ひれ一口カツ・焼肉・シャケ入り"
-          price: "970円"
+          price: "1050円"
 
         - title: "ライス単品"
           description: ""
-          price: "190円"
+          price: "220円"
 
         - title: "ライス大盛り"
           description: ""
-          price: "+54円"
+          price: "+70円"
 
 ################### Subscription ################
 subscription:


### PR DESCRIPTION
## Summary
- Updated pricing for 34 menu items (お惣菜 and お弁当) based on latest menu revision from September 17, 2025
- Price adjustments range from 10円 to 80円 increases across various items
- Updated both individual items and bento combinations

## Test plan
- [ ] Verify all pricing changes are correctly reflected on the website
- [ ] Check that the formatting and display remain consistent
- [ ] Confirm no broken layouts or missing price information

🤖 Generated with [Claude Code](https://claude.ai/code)